### PR TITLE
Enhance pagination functionality and adjust venues per page

### DIFF
--- a/src/components/common/Pagination.jsx
+++ b/src/components/common/Pagination.jsx
@@ -1,4 +1,4 @@
-import React from "react";
+import React, { useEffect } from "react";
 import {
   ArrowLongLeftIcon,
   ArrowLongRightIcon,
@@ -7,20 +7,29 @@ import {
 const Pagination = ({ currentPage, totalCount, pageSize, onPageChange }) => {
   const totalPages = Math.ceil(totalCount / pageSize);
 
+  const handlePageChange = (page) => {
+    onPageChange(page);
+    window.scrollTo(0, 0); // Scroll to the top of the page
+  };
+
   const handlePrevious = () => {
     if (currentPage > 1) {
-      onPageChange(currentPage - 1);
+      handlePageChange(currentPage - 1);
+    } else {
+      handlePageChange(totalPages); // Go to the last page
     }
   };
 
   const handleNext = () => {
     if (currentPage < totalPages) {
-      onPageChange(currentPage + 1);
+      handlePageChange(currentPage + 1);
+    } else {
+      handlePageChange(1); // Go to the first page
     }
   };
 
   const handlePageClick = (page) => {
-    onPageChange(page);
+    handlePageChange(page);
   };
 
   const renderPageNumbers = () => {

--- a/src/pages/Venues.jsx
+++ b/src/pages/Venues.jsx
@@ -10,7 +10,7 @@ import fetchAllVenues from "../services/fetchAllVenues"; // Import fetchAllVenue
 
 export default function Venues() {
   const [currentPage, setCurrentPage] = useState(1);
-  const venuesPerPage = 50;
+  const venuesPerPage = 27;
   const [allFetchedVenues, setAllFetchedVenues] = useState([]); // State to store all fetched venues
   const [venues, setVenues] = useState([]);
   const [loading, setLoading] = useState(true);

--- a/src/services/fetchAllVenues.js
+++ b/src/services/fetchAllVenues.js
@@ -7,7 +7,7 @@ const fetchAllVenues = async () => {
 
   while (true) {
     const response = await fetch(
-      `${API_BASE_URL}${API_VENUES_URL}?_owner=true&_bookings=true&page=${page}`
+      `${API_BASE_URL}${API_VENUES_URL}?_owner=true&_bookings=true&page=${page}&sort=created&sortOrder=desc`
     );
     const data = await response.json();
     if (!Array.isArray(data.data)) {


### PR DESCRIPTION
Improve pagination by scrolling to the top on page change and reducing the venues displayed per page to 27. Additionally, update the API request to include sorting parameters.